### PR TITLE
Cleanup old PR update events

### DIFF
--- a/server/src/adapter/db/prupdates/mod.rs
+++ b/server/src/adapter/db/prupdates/mod.rs
@@ -69,4 +69,14 @@ impl PullRequestEventRepository {
             .context("Could not map DB entities to service entities.")?;
         Ok(mapped_events)
     }
+
+    pub async fn delete_events(&self, events: &[PullRequestEvent]) -> anyhow::Result<()>{
+        let ids : Vec<i32>= events.iter().filter_map(|event| event.id).collect();
+        for id in ids {
+            pull_request_event::Entity::delete_by_id(id)
+                .await
+                .context("Could not delete PR event from DB")?;
+        }
+        Ok(())
+    }
 }

--- a/server/src/adapter/db/prupdates/mod.rs
+++ b/server/src/adapter/db/prupdates/mod.rs
@@ -70,10 +70,11 @@ impl PullRequestEventRepository {
         Ok(mapped_events)
     }
 
-    pub async fn delete_events(&self, events: &[PullRequestEvent]) -> anyhow::Result<()>{
-        let ids : Vec<i32>= events.iter().filter_map(|event| event.id).collect();
+    pub async fn delete_events(&self, events: &[PullRequestEvent]) -> anyhow::Result<()> {
+        let ids: Vec<i32> = events.iter().filter_map(|event| event.id).collect();
         for id in ids {
             pull_request_event::Entity::delete_by_id(id)
+                .exec(&self.db)
                 .await
                 .context("Could not delete PR event from DB")?;
         }

--- a/server/src/service/prupdates/pr_event_service.rs
+++ b/server/src/service/prupdates/pr_event_service.rs
@@ -3,8 +3,10 @@ use crate::service::prupdates::aggregate::aggregate_events;
 use crate::service::prupdates::model::{PullRequestEvent, PullRequestUpdate};
 use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
+use log::{info, log};
 use std::collections::HashMap;
-use std::ops::Sub;
+
+const EVENT_MAX_AGE_DAYS: i64 = 7;
 
 #[derive(Clone)]
 pub struct PullRequestUpdateService {
@@ -58,20 +60,120 @@ impl PullRequestUpdateService {
 
     pub async fn clean_up_pr_updates(&self) -> anyhow::Result<()> {
         // TODO do this directly with where clause once date column is migrated
-        let oldest_timestamp = Utc::now() - Duration::days(7);
+        let oldest_timestamp = Utc::now() - Duration::days(EVENT_MAX_AGE_DAYS);
         let events = self.pr_event_repository.get_events().await?;
 
-        for event in events {
-            if event.timestamp.lt(&oldest_timestamp) {
-                self.pr_event_repository.delete_events()
-            }
+        let events_to_delete: Vec<PullRequestEvent> = events
+            .into_iter()
+            .filter(|event| event.timestamp.lt(&oldest_timestamp))
+            .collect();
+
+        if events_to_delete.len() > 0 {
+            info!("Will delete {} old PR events", events_to_delete.len());
         }
-        let events_to_delete: Vec<PullRequestEvent> = events.into_iter()
-            .filter(|event| {
-                event.timestamp.lt(&oldest_timestamp)
-            }).collect();
-        self.pr_event_repository.delete_events(&events_to_delete)
+
+        self.pr_event_repository
+            .delete_events(&events_to_delete)
             .await
-            .context
+            .context("Could not delete PR updates.")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::adapter::db::prupdates::PullRequestEventRepository;
+    use crate::service::prupdates::model::{
+        PullRequestEvent, PullRequestEventType, PullRequestTimestamp,
+    };
+    use crate::service::prupdates::pr_event_service::{
+        PullRequestUpdateService, EVENT_MAX_AGE_DAYS,
+    };
+    use chrono::{Duration, Utc};
+    use migration::{Migrator, MigratorTrait};
+    use sea_orm::{ConnectOptions, Database};
+    use std::collections::HashMap;
+
+    async fn get_in_memory_repository() -> PullRequestEventRepository {
+        let connect_options = ConnectOptions::new("sqlite::memory:".to_owned());
+        let db_connection = Database::connect(connect_options).await.unwrap();
+        Migrator::up(&db_connection, None).await.unwrap();
+        PullRequestEventRepository::new(db_connection)
+    }
+
+    fn get_pr_event_with_timestamp(id: &str, timestamp: PullRequestTimestamp) -> PullRequestEvent {
+        PullRequestEvent {
+            id: None,
+            pr_id: id.to_owned(),
+            event_type: PullRequestEventType::Opened,
+            author: "author".to_string(),
+            title: "title".to_string(),
+            repository: "repository".to_owned(),
+            text: "text".to_string(),
+            timestamp,
+            pr_link: "pr_link".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn clean_up_pr_updates_everything_new() {
+        let repository = get_in_memory_repository().await;
+        let service = PullRequestUpdateService::new(repository);
+        service
+            .save_pr_event(get_pr_event_with_timestamp(
+                "id1",
+                Utc::now() - Duration::days(1),
+            ))
+            .await
+            .unwrap();
+        service
+            .save_pr_event(get_pr_event_with_timestamp(
+                "id2",
+                Utc::now() - Duration::days(EVENT_MAX_AGE_DAYS - 1),
+            ))
+            .await
+            .unwrap();
+
+        service.clean_up_pr_updates().await.unwrap();
+
+        let events = service.get_pr_updates(HashMap::new()).await.unwrap();
+
+        assert_eq!(2, events.len());
+        assert_eq!("id1", events.get(0).unwrap().pr_id);
+        assert_eq!("id2", events.get(1).unwrap().pr_id);
+    }
+
+    #[tokio::test]
+    async fn clean_up_pr_updates_cleaned_up() {
+        let repository = get_in_memory_repository().await;
+        let service = PullRequestUpdateService::new(repository);
+        service
+            .save_pr_event(get_pr_event_with_timestamp(
+                "id1",
+                Utc::now() - Duration::days(1),
+            ))
+            .await
+            .unwrap();
+        service
+            .save_pr_event(get_pr_event_with_timestamp(
+                "id2",
+                Utc::now() - Duration::days(EVENT_MAX_AGE_DAYS),
+            ))
+            .await
+            .unwrap();
+        service
+            .save_pr_event(get_pr_event_with_timestamp(
+                "id3",
+                Utc::now() - Duration::days(EVENT_MAX_AGE_DAYS + 1),
+            ))
+            .await
+            .unwrap();
+
+        service.clean_up_pr_updates().await.unwrap();
+
+        let events = service.get_pr_updates(HashMap::new()).await.unwrap();
+
+        assert_eq!(1, events.len());
+        assert_eq!("id1", events.get(0).unwrap().pr_id);
     }
 }

--- a/server/src/service/prupdates/pr_event_service.rs
+++ b/server/src/service/prupdates/pr_event_service.rs
@@ -3,7 +3,7 @@ use crate::service::prupdates::aggregate::aggregate_events;
 use crate::service::prupdates::model::{PullRequestEvent, PullRequestUpdate};
 use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
-use log::{info, log};
+use log::info;
 use std::collections::HashMap;
 
 const EVENT_MAX_AGE_DAYS: i64 = 7;
@@ -68,7 +68,7 @@ impl PullRequestUpdateService {
             .filter(|event| event.timestamp.lt(&oldest_timestamp))
             .collect();
 
-        if events_to_delete.len() > 0 {
+        if !events_to_delete.is_empty() {
             info!("Will delete {} old PR events", events_to_delete.len());
         }
 


### PR DESCRIPTION
PR updates are not useful anymore after a certain time. Clean up old entries after 7 days.